### PR TITLE
Expose per-cell non-contacting arc length

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,6 @@ This installs the core package dependencies along with `pytest` required for dev
 
 > [!NOTE]
 > - You can install additional packages as needed using `uv add <package_name>`.
-> - You can install additional packages as needed using `uv add <package_name>`.
 > - In some environments (like HPC clusters), global Python path can contaminate the project environment. You may need to add the `PYTHONPATH=""` prefix to all `uv` commands to isolate the project.
 > - The current version uses **Cython** to translate `.pyx` files into `.cpp`, (and therefore requires a working C/C++ compiler), though [a fallback backend](/pyafv/cell_geom_fallback.py) (based on early pure-Python release) is also implemented.
 > - For *Windows* **MinGW GCC** users (rather than **MSVC**), add a `setup.cfg` file at the repository root:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: wwang721
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -39,13 +39,13 @@ jobs:
 
       # Set up the multi-architecture builder
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: .github/Dockerfile

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up MSVC for ARM64 Windows
         if: matrix.os == 'windows-11-arm'
@@ -29,7 +29,7 @@ jobs:
 
       # Add this step to make 'uv' available to cibuildwheel
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           # This tells the action to watch your project file instead of a lockfile
           cache-dependency-glob: "pyproject.toml"
@@ -57,9 +57,9 @@ jobs:
 
       - name: Build wheels (non-Windows-ARM)
         if: matrix.os != 'windows-11-arm'
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v3.4.1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -68,14 +68,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
         with:
           # This tells the action to watch your project file instead of a lockfile
           cache-dependency-glob: "pyproject.toml"
 
       - run: uv build --sdist # Build the .tar.gz file
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -89,7 +89,7 @@ jobs:
     permissions:
       id-token: write # Required for Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -67,6 +67,6 @@ jobs:
           uv run pytest --cov=pyafv --cov-branch --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests_all_platform.yml
+++ b/.github/workflows/tests_all_platform.yml
@@ -35,10 +35,10 @@ jobs:
             python: "3.14t"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -63,7 +63,7 @@ jobs:
 
       # Add this step to make 'uv' available to cibuildwheel
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           # This tells the action to watch your project file instead of a lockfile
           cache-dependency-glob: "pyproject.toml"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
   given-names: "Brian A."
   orcid: "https://orcid.org/0000-0002-0765-6956"
 title: "PyAFV: A Python package for active finite Voronoi simulations of nonconfluent tissues"
-version: v0.4.10
+version: v0.4.11
 doi: 10.5281/zenodo.18091659
-date-released: 2026-04-22
+date-released: 2026-05-13
 url: "https://github.com/wwang721/pyafv"
 preferred-citation:
   type: article

--- a/pyafv/_version.py
+++ b/pyafv/_version.py
@@ -1,2 +1,2 @@
 # pyafv/_version.py
-__version__ = "0.4.10"
+__version__ = "0.4.11"

--- a/pyafv/cell_geom.pyx
+++ b/pyafv/cell_geom.pyx
@@ -325,6 +325,7 @@ def compute_vertex_derivatives(
     cdef object dP_poly_dh_np = np.zeros((num_vertices_ext + 2*num_ridges, 2), dtype=np.float64)
     cdef object area_list_np = np.zeros(N, dtype=np.float64)
     cdef object perimeter_list_np = np.zeros(N, dtype=np.float64)
+    cdef object arclen_list_np = np.zeros(N, dtype=np.float64)
 
     cdef cnp.float64_t[:, :] vertex_out_da_dtheta = vertex_out_da_dtheta_np
     cdef cnp.float64_t[:, :] vertex_out_dl_dtheta = vertex_out_dl_dtheta_np
@@ -332,6 +333,7 @@ def compute_vertex_derivatives(
     cdef cnp.float64_t[:, :] dP_poly_dh = dP_poly_dh_np
     cdef cnp.float64_t[:] area_list = area_list_np
     cdef cnp.float64_t[:] perimeter_list = perimeter_list_np
+    cdef cnp.float64_t[:] arclen_list = arclen_list_np
 
     # declarations used inside loop (declare here, assign in loop)
     cdef object edges_type_obj
@@ -398,6 +400,7 @@ def compute_vertex_derivatives(
         if E < 2:
             area_list[i] = 3.14159265358979323846 * (r * r)
             perimeter_list[i] = 2.0 * 3.14159265358979323846 * r
+            arclen_list[i] = 2.0 * 3.14159265358979323846 * r
             continue
 
         # ring indices
@@ -467,6 +470,7 @@ def compute_vertex_derivatives(
         Ai = Ai_straight + Ai_arc
         perimeter_list[i] = Pi
         area_list[i] = Ai
+        arclen_list[i] = Pi_arc
 
         # ----- dA_poly/dh, dP_poly/dh for v1 -----
         for j in range(E):
@@ -537,4 +541,5 @@ def compute_vertex_derivatives(
             dA_poly_dh_np,
             dP_poly_dh_np,
             area_list_np,
-            perimeter_list_np)
+            perimeter_list_np,
+            arclen_list_np)

--- a/pyafv/cell_geom_fallback.py
+++ b/pyafv/cell_geom_fallback.py
@@ -152,6 +152,7 @@ def compute_vertex_derivatives(
 
     area_list = np.zeros(N)
     perimeter_list = np.zeros(N)
+    arclen_list = np.zeros(N)
 
     for idx in range(N):
         edges_type = np.asarray(point_edges_type[idx], dtype=int)
@@ -161,6 +162,7 @@ def compute_vertex_derivatives(
         if E < 2:
             area_list[idx] = np.pi * (r ** 2)
             perimeter_list[idx] = 2.0 * np.pi * r
+            arclen_list[idx] = 2.0 * np.pi * r
             continue
 
         # ring indices
@@ -199,6 +201,7 @@ def compute_vertex_derivatives(
         Pi = Pi_straight + Pi_arc
         Ai = Ai_straight + Ai_arc
         perimeter_list[idx] = Pi
+        arclen_list[idx] = Pi_arc
         area_list[idx] = Ai
 
         # ----- dA_poly/dh, dP_poly/dh for v1 -----
@@ -252,4 +255,4 @@ def compute_vertex_derivatives(
                     vertex_out_da_dtheta[k2v, which2] = da2_arc[valid2]
                     vertex_out_dl_dtheta[k2v, which2] = dl2
 
-    return vertex_out_da_dtheta, vertex_out_dl_dtheta, dA_poly_dh, dP_poly_dh, area_list, perimeter_list
+    return vertex_out_da_dtheta, vertex_out_dl_dtheta, dA_poly_dh, dP_poly_dh, area_list, perimeter_list, arclen_list

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -323,6 +323,7 @@ class FiniteVoronoiSimulator:
                 - **dP_poly_dh**: Array of dP_polygon/dh for each vertex.
                 - **area_list**: Array of polygon areas for each cell.
                 - **perimeter_list**: Array of polygon perimeters for each cell.
+                - **arclen_list**: Array of non-contacting arc lengths for each cell.
                 - **point_edges_type**: List of lists of edge types per cell.
                 - **point_vertices_f_idx**: List of lists of vertex ids per cell.
                 - **num_vertices_ext**: Number of vertices including infinite extension vertices.
@@ -474,7 +475,7 @@ class FiniteVoronoiSimulator:
         # --------------------------------------------------
         # Part 2 in Cython/Python backend
         # --------------------------------------------------
-        vertex_out_da_dtheta, vertex_out_dl_dtheta, dA_poly_dh, dP_poly_dh, area_list, perimeter_list = self._impl.compute_vertex_derivatives(
+        vertex_out_da_dtheta, vertex_out_dl_dtheta, dA_poly_dh, dP_poly_dh, area_list, perimeter_list, arclen_list = self._impl.compute_vertex_derivatives(
             point_edges_type,            # list-of-lists / arrays of edge types
             point_vertices_f_idx,        # list-of-lists / arrays of vertex ids
             vertices_all.astype(np.float64, copy=False),
@@ -498,6 +499,7 @@ class FiniteVoronoiSimulator:
             dP_poly_dh=dP_poly_dh,
             area_list=area_list,
             perimeter_list=perimeter_list,
+            arclen_list=arclen_list,
             point_edges_type=point_edges_type,
             point_vertices_f_idx=point_vertices_f_idx,
             num_vertices_ext=num_vertices_ext,
@@ -757,6 +759,7 @@ class FiniteVoronoiSimulator:
                 - **forces**: (N,2) array of forces on cell centers
                 - **areas**: (N,) array of cell areas
                 - **perimeters**: (N,) array of cell perimeters
+                - **arclens**: (N,) array of non-contacting edge (arc) lengths per cell
                 - **vertices**: (M,2) array of all Voronoi + extension vertices
                 - **edges_type**: List-of-lists of edge types per cell (1=straight, 0=circular arc)
                 - **regions**: List-of-lists of vertex indices per cell
@@ -799,6 +802,7 @@ class FiniteVoronoiSimulator:
             forces=F,
             areas=geom["area_list"],
             perimeters=geom["perimeter_list"],
+            arclens=geom["arclen_list"],
             vertices=vertices_all,
             edges_type=geom["point_edges_type"],
             regions=geom["point_vertices_f_idx"],


### PR DESCRIPTION
## Summary
- Surface a new per-cell quantity `arclens` (sum of non-contacting arc edge lengths, equal to `2*pi*r` for degenerate isolated cells) from both the Cython and Python-fallback `compute_vertex_derivatives` backends, threaded through `_per_cell_geometry` and the public `build()` return dict. Intended as a building block for tracking system energy.
- Drive-by fixes: remove a duplicate `uv add` bullet in `CONTRIBUTING.md` and bump GitHub Actions / cibuildwheel pins in the CI/release workflows to their current major versions.

Closes #49.

## Test plan
- [x] `uv run pytest` passes on both Cython and Python backends
- [x] `sim.build()["arclens"]` returns an `(N,)` array; a degenerate isolated cell reports `2*pi*r`; a fully-contacting cell reports `0`
- [x] CI / release workflows trigger and succeed with the bumped action versions