### PR TITLE
Expose per-cell coordination number

### DIFF
--- a/pyafv/cell_geom.pyx
+++ b/pyafv/cell_geom.pyx
@@ -142,6 +142,7 @@ def build_point_edges(
     cdef Py_ssize_t N = pts.shape[0]
     cdef list point_edges_type = [None] * N
     cdef list point_vertices_f_idx = [None] * N
+    cdef cnp.int64_t[:] coord_nums = np.zeros(N, dtype=np.int64)
 
     # packed (v1,v2) -> ridge_id
     cdef dict pair2ridge = {}
@@ -283,8 +284,9 @@ def build_point_edges(
 
         point_edges_type[idx] = edges_type
         point_vertices_f_idx[idx] = vertices_f_idx
+        coord_nums[idx] = sum(edges_type)
 
-    return point_edges_type, point_vertices_f_idx
+    return point_edges_type, point_vertices_f_idx, np.asarray(coord_nums)
 
 
 # ---------------------------------------------------------------------------------------

--- a/pyafv/cell_geom_fallback.py
+++ b/pyafv/cell_geom_fallback.py
@@ -57,6 +57,7 @@ def build_point_edges(vor_regions, point_region,
 
     point_edges_type = []
     point_vertices_f_idx = []
+    coord_nums = np.zeros(N, dtype=int)
 
     # --- fast vectorized per-cell processing (no inner edge loop) ---
     for idx in range(N):
@@ -122,8 +123,10 @@ def build_point_edges(vor_regions, point_region,
 
         point_edges_type.append(edges_type)
         point_vertices_f_idx.append(vertices_f_idx)
+        
+        coord_nums[idx] = np.sum(edges_type, dtype=int)
 
-    return point_edges_type, point_vertices_f_idx
+    return point_edges_type, point_vertices_f_idx, coord_nums
 
 
 def compute_vertex_derivatives(

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -327,6 +327,7 @@ class FiniteVoronoiSimulator:
                 - **point_edges_type**: List of lists of edge types per cell.
                 - **point_vertices_f_idx**: List of lists of vertex ids per cell.
                 - **num_vertices_ext**: Number of vertices including infinite extension vertices.
+                - **coord_nums**: (N,) integer array of coordination numbers per cell.
         """
         N = self.N
         r = self.phys.r
@@ -464,7 +465,7 @@ class FiniteVoronoiSimulator:
         # Part 1 in Cython/Python backend
         # --------------------------------------------------
         vor_regions = self._impl.pad_regions(vor.regions)            # (R, Kmax) int64 with -1 padding
-        point_edges_type, point_vertices_f_idx = self._impl.build_point_edges(
+        point_edges_type, point_vertices_f_idx, coord_nums = self._impl.build_point_edges(
             vor_regions, vor.point_region.astype(np.int64),
             vertices_all.astype(np.float64), pts.astype(np.float64),
             int(num_vertices), vertexpair2ridge, 
@@ -503,6 +504,7 @@ class FiniteVoronoiSimulator:
             point_edges_type=point_edges_type,
             point_vertices_f_idx=point_vertices_f_idx,
             num_vertices_ext=num_vertices_ext,
+            coord_nums=coord_nums,
         )
         return diagnostics, vertices_all
 
@@ -764,6 +766,7 @@ class FiniteVoronoiSimulator:
                 - **edges_type**: List-of-lists of edge types per cell (1=straight, 0=circular arc)
                 - **regions**: List-of-lists of vertex indices per cell
                 - **connections**: (K,2) array of connected cell index pairs
+                - **coord_nums**: (N,) integer array of coordination numbers per cell
         """
         (vor, vertices_all, ridge_vertices_all, num_vertices,
             vertexpair2ridge, vertex_points) = self._build_voronoi_with_extensions()
@@ -807,6 +810,7 @@ class FiniteVoronoiSimulator:
             edges_type=geom["point_edges_type"],
             regions=geom["point_vertices_f_idx"],
             connections=connections,
+            coord_nums=geom["coord_nums"],
         )
 
     # --------------------- 2D plotting utilities ---------------------

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -762,11 +762,11 @@ class FiniteVoronoiSimulator:
                 - **areas**: (N,) array of cell areas
                 - **perimeters**: (N,) array of cell perimeters
                 - **arclens**: (N,) array of non-contacting edge (arc) lengths per cell
+                - **coord_nums**: (N,) integer array of coordination numbers per cell
                 - **vertices**: (M,2) array of all Voronoi + extension vertices
                 - **edges_type**: List-of-lists of edge types per cell (1=straight, 0=circular arc)
                 - **regions**: List-of-lists of vertex indices per cell
                 - **connections**: (K,2) array of connected cell index pairs
-                - **coord_nums**: (N,) integer array of coordination numbers per cell
         """
         (vor, vertices_all, ridge_vertices_all, num_vertices,
             vertexpair2ridge, vertex_points) = self._build_voronoi_with_extensions()

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -51,6 +51,12 @@ def test_geom(data_dir, simulator):
     simulator.update_positions(pts)
     diag = simulator.build()
 
+    # Test coordination number
+    zs = diag['coord_nums']
+    connect_matrix = afv.rebuild_connection_matrix(pts.shape[0], diag["connections"])
+    z_values = connect_matrix.getnnz(axis=1)
+    assert np.all(zs == z_values)
+
     #-----------------------------
     simulator.plot_2d()
     N = pts.shape[0]


### PR DESCRIPTION
Closes #51

## Summary
- Add `coord_nums` (N,) integer array to both Cython and Python backends, counting the number of straight Voronoi edges (i.e., contacts) per cell
- Thread `coord_nums` through `_per_cell_geometry` diagnostics and expose it in the `build()` return dict
- Add test asserting `coord_nums` matches the degree of the connection matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)