### PR TITLE
Add binned domain decomposition method

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
   given-names: "Brian A."
   orcid: "https://orcid.org/0000-0002-0765-6956"
 title: "PyAFV: A Python package for active finite Voronoi simulations of nonconfluent tissues"
-version: v0.4.12
+version: v0.4.13
 doi: 10.5281/zenodo.18091659
-date-released: 2026-05-27
+date-released: 2026-05-31
 url: "https://github.com/wwang721/pyafv"
 preferred-citation:
   type: article

--- a/docs/multiprocessing.rst
+++ b/docs/multiprocessing.rst
@@ -151,6 +151,8 @@ simulator both support two halo-collection methods:
 
 - ``"dense"`` is the default. It builds a dense domain-by-point mask and is
   often faster for moderate systems.
+- ``"binned"`` reuses the owned-domain bins to check fewer candidate halo
+  points. It can be faster for large systems with many domains.
 - ``"sorted_x"`` avoids the dense temporary mask by sorting points along the
   ``x``-axis and querying candidate halo ranges. It uses less temporary memory,
   but can be slower for typical moderate-sized systems.

--- a/docs/multiprocessing.rst
+++ b/docs/multiprocessing.rst
@@ -137,7 +137,7 @@ Decomposition method
 --------------------
 
 The low-level helper :py:func:`pyafv.decompose_points` and the parallel
-simulator both support two halo-collection methods:
+simulator both support three halo-collection methods:
 
 .. code-block:: python
 

--- a/pyafv/_version.py
+++ b/pyafv/_version.py
@@ -1,2 +1,2 @@
 # pyafv/_version.py
-__version__ = "0.4.12"
+__version__ = "0.4.13"

--- a/pyafv/parallel_voronoi.py
+++ b/pyafv/parallel_voronoi.py
@@ -128,7 +128,7 @@ def decompose_points(
     halo_width: float = 0.0,
     *,
     domain_bounds: tuple[tuple[float, float], tuple[float, float]] | None = None,
-    method: typing.Literal["dense", "sorted_x"] = "dense",
+    method: typing.Literal["dense", "binned", "sorted_x"] = "dense",
 ) -> list[DomainDecomposition]:
     """Decompose points into owned grid domains plus halo/local points.
 
@@ -149,7 +149,9 @@ def decompose_points(
             If *None*, bounds are inferred from *points*.
         method: Method used to collect halo points. ``"dense"`` builds a
             dense domain-by-point mask and is usually faster for moderate
-            systems. ``"sorted_x"`` uses less temporary memory.
+            systems. ``"binned"`` reuses the owned-domain bins to reduce the
+            number of candidate points checked for each halo and is usually
+            faster for many domains. ``"sorted_x"`` uses less temporary memory.
 
     Returns:
         list[DomainDecomposition]: One list of :py:class:`DomainDecomposition` objects in row-major order,
@@ -169,8 +171,8 @@ def decompose_points(
     halo_width = float(halo_width)
     if halo_width < 0.0:                   # pragma: no cover
         raise ValueError("halo_width must be non-negative")
-    if method not in ("dense", "sorted_x"):                   # pragma: no cover
-        raise ValueError("method must be 'dense' or 'sorted_x'")
+    if method not in ("dense", "binned", "sorted_x"):                   # pragma: no cover
+        raise ValueError("method must be 'dense', 'binned', or 'sorted_x'")
 
     nx, ny = _validate_grid_shape(grid_shape)
     n_domains = nx * ny
@@ -251,6 +253,17 @@ def decompose_points(
         local_domain_ids, local_global_ids_all = np.nonzero(local_mask)
         local_counts = np.bincount(local_domain_ids, minlength=n_domains)
         local_starts = np.concatenate(([0], np.cumsum(local_counts)))
+    elif method == "binned":
+        px = points[:, 0]
+        py = points[:, 1]
+        candidate_ix0 = np.searchsorted(x_edges, halo_x0, side="right") - 1
+        candidate_ix1 = np.searchsorted(x_edges, halo_x1, side="right") - 1
+        candidate_iy0 = np.searchsorted(y_edges, halo_y0, side="right") - 1
+        candidate_iy1 = np.searchsorted(y_edges, halo_y1, side="right") - 1
+        candidate_ix0 = np.clip(candidate_ix0, 0, nx - 1)
+        candidate_ix1 = np.clip(candidate_ix1, 0, nx - 1)
+        candidate_iy0 = np.clip(candidate_iy0, 0, ny - 1)
+        candidate_iy1 = np.clip(candidate_iy1, 0, ny - 1)
     else:
         py = points[:, 1]
         x_order = np.argsort(points[:, 0], kind="stable")
@@ -268,6 +281,28 @@ def decompose_points(
             local_global_ids = local_global_ids_all[
                 local_starts[domain_id] : local_starts[domain_id + 1]
             ]
+        elif method == "binned":
+            candidate_chunks = []
+            for iy_candidate in range(candidate_iy0[domain_id], candidate_iy1[domain_id] + 1):
+                row_start = iy_candidate * nx
+                for ix_candidate in range(candidate_ix0[domain_id], candidate_ix1[domain_id] + 1):
+                    candidate_domain_id = row_start + ix_candidate
+                    candidate_chunks.append(
+                        owned_order[
+                            owned_starts[candidate_domain_id] : owned_starts[candidate_domain_id + 1]
+                        ]
+                    )
+            if len(candidate_chunks) == 1:
+                candidate_global_ids = candidate_chunks[0]
+            else:
+                candidate_global_ids = np.concatenate(candidate_chunks)
+            local_mask = (
+                (px[candidate_global_ids] >= halo_x0[domain_id])
+                & (px[candidate_global_ids] <= halo_x1[domain_id])
+                & (py[candidate_global_ids] >= halo_y0[domain_id])
+                & (py[candidate_global_ids] <= halo_y1[domain_id])
+            )
+            local_global_ids = np.sort(candidate_global_ids[local_mask])
         else:
             x_candidates = x_order[
                 halo_x_left[domain_id] : halo_x_right[domain_id]
@@ -405,8 +440,8 @@ class ParallelFiniteVoronoiSimulator:
         domain_bounds: Optional domain bounds as ``((xmin, xmax), (ymin, ymax))``.
             If *None*, bounds are inferred from the current point positions.
         decomposition_method: Method used to collect halo points. ``"dense"``
-            is usually faster for moderate systems, while ``"sorted_x"`` uses
-            less temporary memory.
+            is usually faster for moderate systems. ``"binned"`` can be faster
+            for many domains. ``"sorted_x"`` uses less temporary memory.
 
     Raises:
         ValueError: If *pts* does not have shape (N,2).
@@ -434,7 +469,7 @@ class ParallelFiniteVoronoiSimulator:
         halo_width: float | None = None,
         backend: typing.Literal["cython", "python"] | None = None,
         domain_bounds: tuple[tuple[float, float], tuple[float, float]] | None = None,
-        decomposition_method: typing.Literal["dense", "sorted_x"] = "dense",
+        decomposition_method: typing.Literal["dense", "binned", "sorted_x"] = "dense",
     ):
         pts = np.asarray(pts, dtype=float)
         if pts.ndim != 2 or pts.shape[1] != 2:                   # pragma: no cover
@@ -457,8 +492,8 @@ class ParallelFiniteVoronoiSimulator:
             raise ValueError("n_workers must be positive")
         self.backend = backend
         self.domain_bounds = _validate_domain_bounds(domain_bounds)
-        if decomposition_method not in ("dense", "sorted_x"):                   # pragma: no cover
-            raise ValueError("decomposition_method must be 'dense' or 'sorted_x'")
+        if decomposition_method not in ("dense", "binned", "sorted_x"):                   # pragma: no cover
+            raise ValueError("decomposition_method must be 'dense', 'binned', or 'sorted_x'")
         self.decomposition_method = decomposition_method
         self._preferred_areas = np.full(self.N, phys.A0, dtype=float)
         self._executor: ProcessPoolExecutor | None = None

--- a/tests/test_bench_decompose_points.py
+++ b/tests/test_bench_decompose_points.py
@@ -1,0 +1,50 @@
+"""
+Benchmarks for pyafv.decompose_points halo-collection methods.
+
+The parameter grid compares the available decomposition methods over several
+system sizes and domain grids. Benchmarks use fixed point sets so methods see
+the same input for a given system size.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyafv as afv
+
+
+SYSTEM_SIZES = [10_000, 100_000, 1_000_000]
+GRID_SHAPES = [(4, 3), (8, 6), (16, 12)]
+METHODS = ["dense", "binned", "sorted_x"]
+RADIUS = 1.0
+HALO_WIDTH = 4.01 * RADIUS
+SEED = 42
+
+
+@pytest.fixture(scope="module")
+def point_sets() -> dict[int, np.ndarray]:
+    return {
+        n_points: make_points(n_points)
+        for n_points in SYSTEM_SIZES
+    }
+
+
+def make_points(n_points: int) -> np.ndarray:
+    rng = np.random.default_rng(SEED + n_points)
+    box_size = np.sqrt(n_points) * RADIUS
+    return rng.random((n_points, 2)) * box_size
+
+
+@pytest.mark.parametrize("method", METHODS)
+@pytest.mark.parametrize("grid_shape", GRID_SHAPES, ids=lambda grid: f"{grid[0]}x{grid[1]}")
+@pytest.mark.parametrize("n_points", SYSTEM_SIZES, ids=lambda n: f"N={n}")
+def test_decompose_points_methods(benchmark, point_sets, n_points, grid_shape, method):
+    points = point_sets[n_points]
+    benchmark.pedantic(
+        afv.decompose_points,
+        args=(points, grid_shape, HALO_WIDTH),
+        kwargs={"method": method},
+        rounds=5,
+        iterations=1,
+    )

--- a/tests/test_bench_parallel_build.py
+++ b/tests/test_bench_parallel_build.py
@@ -1,0 +1,57 @@
+"""
+Benchmarks for pyafv.ParallelFiniteVoronoiSimulator.build.
+
+These benchmarks measure the domain-task construction step and the repeated
+``build(connect=False)`` call. The worker pool is kept alive during the build
+benchmark so that process-pool startup is not included.
+"""
+
+import numpy as np
+import pytest
+
+import pyafv as afv
+
+
+@pytest.fixture(scope="module")
+def parallel_pts() -> np.ndarray:
+    rng = np.random.default_rng(42)
+    n_points = 100_000
+    return rng.random((n_points, 2)) * np.sqrt(n_points)
+
+
+@pytest.fixture(scope="module")
+def parallel_phys() -> afv.PhysicalParams:
+    return afv.PhysicalParams(r=1.0)
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param((2, 2), id="2x2"),
+        pytest.param((3, 3), id="3x3"),
+        pytest.param((4, 3), id="4x3"),
+    ],
+)
+def parallel_simulator(request, parallel_pts, parallel_phys):
+    grid_shape = request.param
+    n_workers = grid_shape[0] * grid_shape[1]
+    sim = afv.ParallelFiniteVoronoiSimulator(
+        parallel_pts,
+        parallel_phys,
+        grid_shape=grid_shape,
+        n_workers=n_workers,
+    )
+    with sim:
+        yield sim
+
+
+def test_parallel_make_domain_tasks(benchmark, parallel_simulator):
+    benchmark(
+        parallel_simulator._make_domain_tasks,
+        connect=False,
+        plot_mode=False,
+    )
+
+
+def test_parallel_full_build(benchmark, parallel_simulator):
+    benchmark(parallel_simulator.build, connect=False)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -68,16 +68,28 @@ def test_decompose_points_methods_match():
         domain_bounds=((0.0, 8.0), (0.0, 5.0)),
         method="sorted_x",
     )
+    binned_domains = afv.decompose_points(
+        pts,
+        grid_shape=(4, 3),
+        halo_width=0.4,
+        domain_bounds=((0.0, 8.0), (0.0, 5.0)),
+        method="binned",
+    )
 
-    for dense_domain, sorted_domain in zip(dense_domains, sorted_domains):
-        np.testing.assert_array_equal(
-            sorted_domain.local_global_ids,
-            dense_domain.local_global_ids,
-        )
-        np.testing.assert_array_equal(
-            sorted_domain.owned_local_ids,
-            dense_domain.owned_local_ids,
-        )
+    for dense_domain, sorted_domain, binned_domain in zip(
+        dense_domains,
+        sorted_domains,
+        binned_domains,
+    ):
+        for domain in (sorted_domain, binned_domain):
+            np.testing.assert_array_equal(
+                domain.local_global_ids,
+                dense_domain.local_global_ids,
+            )
+            np.testing.assert_array_equal(
+                domain.owned_local_ids,
+                dense_domain.owned_local_ids,
+            )
 
 
 def test_decompose_points_one_domain_allows_zero_span_axes():


### PR DESCRIPTION
## Summary

- Add a `binned` halo-collection method for `decompose_points` and `ParallelFiniteVoronoiSimulator`.
- Keep `dense` as the default while documenting when `binned` can be useful.
- Extend decomposition-method tests to compare `binned` against `dense` and `sorted_x`.
- Add pytest-benchmark coverage for decomposition methods and parallel build timing.

## Validation

- Direct equivalence check comparing `dense`, `binned`, and `sorted_x` local/owned indices for sampled grids: `pytest --cov=pyafv --cov-branch --cov-report=html`
- `pytest tests/test_bench_decompose_points.py --benchmark-only --benchmark-warmup on --benchmark-histogram`
- `pytest tests/test_bench_parallel_build.py --benchmark-only --benchmark-warmup on --benchmark-histogram`