### PR TITLE
Referee-report revisions: expose seed & num_vertices, contact-truncation docs, rosette fallback warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Below are representative simulation snapshots generated using the code:
     * [QhullError when 3+ points are collinear #1](https://github.com/wwang721/pyafv/issues/1) [Closed - see [comments](https://github.com/wwang721/pyafv/issues/1#issuecomment-3701355742)]
     *  [Add customized plotting to examples illustrating access to vertices and edges #5](https://github.com/wwang721/pyafv/issues/5) [Completed in PR [#7](https://github.com/wwang721/pyafv/pull/7)]
     * [Time step dependence of intercellular adhesion in simulations #8](https://github.com/wwang721/pyafv/issues/8) [Closed in PR [#9](https://github.com/wwang721/pyafv/pull/9)]
-    * [Handle degenerate 4-fold Voronoi vertices causing unpacking errors in _assemble_forces #38](https://github.com/wwang721/pyafv/issues/38) [Closed in PR [#42](https://github.com/wwang721/pyafv/pull/42)]
+    * [Handle degenerate 4-fold Voronoi vertices causing unpacking errors in _assemble_forces #38](https://github.com/wwang721/pyafv/issues/38) [Mentioned in PR [#42](https://github.com/wwang721/pyafv/pull/42) and PR [#58](https://github.com/wwang721/pyafv/pull/58)]
 
 - Some releases of this repository are cross-listed on [Zenodo](https://doi.org/10.5281/zenodo.18091659):
 

--- a/assets/active_FV_default.png
+++ b/assets/active_FV_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b338ee5b376ce40f1abb6e549de9589af80958005c60953ef8919438fd3efac7
+size 383633

--- a/docs/api/PhysicalParams.rst
+++ b/docs/api/PhysicalParams.rst
@@ -17,6 +17,7 @@
       ~PhysicalParams.KP
       ~PhysicalParams.Lambda
       ~PhysicalParams.delta
+      ~PhysicalParams.seed
 
    .. rubric:: Methods
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -57,12 +57,22 @@ where the noise satisfies :math:`\langle \eta_i(t) \rangle = 0` and :math:`\lang
 .. literalinclude:: ../examples/active_FV.py
    :language: python
 
-See the plotted figure below:
+See the plotted figures below:
 
-.. image:: ../assets/active_FV.png
-   :alt: AFV dynamics
-   :width: 500px
-   :align: center
+.. list-table::
+   :widths: 50 50
+
+   * - .. figure:: ../assets/active_FV_default.png
+          :width: 500px
+          :align: center
+
+          With contact truncation (default).
+
+     - .. figure:: ../assets/active_FV.png
+          :width: 500px
+          :align: center
+
+          No contact truncation (:math:`\delta=0`).
 
 |
 

--- a/examples/active_FV.py
+++ b/examples/active_FV.py
@@ -20,12 +20,10 @@ phys = afv.PhysicalParams(
     P0=4.8*radius,
     KA=1.0,
     KP=1.0,
-    Lambda=0.2
+    Lambda=0.2,
+    # delta=0.0,
 )
 
-# Do not set delta unless you know what you are doing.
-# We set it to zero here for comparison with the our primitive results.
-phys = phys.replace(delta=0.0)
 
 # Initial positions and orientations
 pts = np.random.rand(N, 2)*0.3 + 0.35  # shape (N,2)

--- a/pyafv/_version.py
+++ b/pyafv/_version.py
@@ -1,2 +1,2 @@
 # pyafv/_version.py
-__version__ = "0.4.15"
+__version__ = "0.4.16"

--- a/pyafv/calibrate/core.py
+++ b/pyafv/calibrate/core.py
@@ -31,7 +31,7 @@ def _tqdm(it: Iterable[T], desc: str = "") -> tuple[Iterable[T], bool]:         
 
 
 def auto_calibrate(phys: PhysicalParams, ext_forces: np.ndarray | None = None,
-                   dt: float = 1e-3, nsteps: int = 50_000, show: bool | None = None) -> tuple[float, PhysicalParams]:
+                   num_vertices: int | None = None, dt: float = 1e-3, nsteps: int = 50_000, show: bool | None = None) -> tuple[float, PhysicalParams]:
     """
     Auto-calibrate the parameters *phys* against the deformable polygon (DP) model.
 
@@ -42,8 +42,10 @@ def auto_calibrate(phys: PhysicalParams, ext_forces: np.ndarray | None = None,
     Args:
         phys: The initial physical parameters.
         ext_forces: An array of external forces to apply during calibration;
-            defaults to None, which uses ``np.linspace(0, 10, 101)[1:]``;
+            defaults to *None*, which uses ``np.linspace(0, 10, 101)[1:]``;
             should start from a small positive value.
+        num_vertices: Number of vertices :math:`M` to use.
+            If set to *None* (the default here), the default value from :py:class:`DeformablePolygonSimulator` is used.
         dt: Time step for each simulation step.
         nsteps: Number of simulation steps to run for each external force.
         show: Whether to print progress information; no need to set it if **tqdm** is installed.
@@ -65,7 +67,7 @@ def auto_calibrate(phys: PhysicalParams, ext_forces: np.ndarray | None = None,
         :py:class:`DeformablePolygonSimulator` model separately to ensure accuracy is acceptable.
     """
 
-    sim = DeformablePolygonSimulator(phys)
+    sim = DeformablePolygonSimulator(phys) if num_vertices is None else DeformablePolygonSimulator(phys, num_vertices=num_vertices)
 
     if sim.detached: # already detached at zero force (steady state)
         detachment_force = 0.0

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -540,8 +540,9 @@ class FiniteVoronoiSimulator:
             I = np.empty(len(H), dtype=int)
             J = np.empty(len(H), dtype=int)
             K = np.empty(len(H), dtype=int)
+
+            _warned_inner_vertex_fallback = False
             for t, h in enumerate(H):
-                _warned_inner_vertex_fallback = False
                 try:
                     I[t], J[t], K[t] = vertex_points[h]
                 except ValueError:
@@ -863,14 +864,21 @@ class FiniteVoronoiSimulator:
 
     # --------------------- One integration step ---------------------
     def build(self, connect: bool = True) -> dict[str, object]:
-        """ Build the finite Voronoi structure and compute forces, returning a dictionary of diagnostics.
+        r""" Build the finite Voronoi structure and compute forces, returning a dictionary of diagnostics.
 
         Do the following:
           - Build Voronoi (+ extensions)
           - Get cell connectivity
           - Compute per-cell quantities and derivatives
           - Assemble forces
-        
+
+        .. note::
+            With a non-zero contact truncation threshold :math:`\delta` in the given parameters *phys*, the force
+            near detachment is not :math:`-\nabla E` from any smooth energy :math:`E`. This is deliberate, and it does
+            no harm for the overdamped dynamics and fracture statistics, but it means the energy is not a Lyapunov
+            function in the cutoff region, and anything energy- or Hessian-based (rigidity, inherent structures,
+            detailed balance) needs care.
+
         Args:
             connect: Whether to compute cell connectivity information.
                 Setting this to ``False`` saves some computation time (though

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -546,7 +546,7 @@ class FiniteVoronoiSimulator:
                 except ValueError:
                     # Fallback to **random** triple if a inner vertex is associated with 4 or more points.
                     import random
-                    I[t], J[t], K[t] = random.sample(range(N), 3)
+                    I[t], J[t], K[t] = random.sample(vertex_points[h], 3)
 
 
             ri = pts[I]  # (H,2)

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -541,6 +541,7 @@ class FiniteVoronoiSimulator:
             J = np.empty(len(H), dtype=int)
             K = np.empty(len(H), dtype=int)
             for t, h in enumerate(H):
+                _warned_inner_vertex_fallback = False
                 try:
                     I[t], J[t], K[t] = vertex_points[h]
                 except ValueError:
@@ -549,6 +550,16 @@ class FiniteVoronoiSimulator:
                     rng = random.Random(self.phys.seed)
                     I[t], J[t], K[t] = rng.sample(vertex_points[h], 3)
 
+                    # print warning to inform user about fallback
+                    if not _warned_inner_vertex_fallback:
+                        import warnings
+                        warnings.warn(
+                            "At least one inner vertex is associated with 4 or more points. "
+                            "Using a random triple of points for force computation.",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
+                    _warned_inner_vertex_fallback = True
 
             ri = pts[I]  # (H,2)
             rj = pts[J]

--- a/pyafv/finite_voronoi.py
+++ b/pyafv/finite_voronoi.py
@@ -546,7 +546,8 @@ class FiniteVoronoiSimulator:
                 except ValueError:
                     # Fallback to **random** triple if a inner vertex is associated with 4 or more points.
                     import random
-                    I[t], J[t], K[t] = random.sample(vertex_points[h], 3)
+                    rng = random.Random(self.phys.seed)
+                    I[t], J[t], K[t] = rng.sample(vertex_points[h], 3)
 
 
             ri = pts[I]  # (H,2)

--- a/pyafv/physical_params.py
+++ b/pyafv/physical_params.py
@@ -127,6 +127,7 @@ class PhysicalParams:
         
         .. important::
             In the returned instance, the contact truncation threshold :py:attr:`delta` is set to 0.45*r by default.
+            The optimal radius :math:`\ell_0` is computed by minimizing the closed-form energy of a cell doublet.
         """
         l, d = self.get_steady_state()
 

--- a/pyafv/physical_params.py
+++ b/pyafv/physical_params.py
@@ -22,6 +22,25 @@ def _require_float_scalar(x: object, name: str) -> float:       # pragma: no cov
     raise TypeError(f"{name} must be a real scalar (float-like), got {type(x).__name__}")
 
 
+def _require_nonnegative_int_scalar(x: object, name: str) -> int:       # pragma: no cover
+    """
+    Accept Python int and NumPy integer scalars.
+    Reject other types (including bool).
+    Return a normalized Python int.
+    """
+    # Reject bool explicitly (since bool is a subclass of int)
+    if isinstance(x, bool):
+        raise TypeError(f"{name} must be a non-negative integer scalar, got bool")
+    elif isinstance(x, (int, np.integer)):
+        xi = int(x)
+        if xi < 0:
+            raise ValueError(f"{name} must be non-negative, got {x}")
+        return xi
+
+    # Reject everything else
+    raise TypeError(f"{name} must be a non-negative integer scalar, got {type(x).__name__}")
+
+
 def sigmoid(x):
     # stable sigmoid that handles large |x|
     if x >= 0:
@@ -48,6 +67,7 @@ class PhysicalParams:
         KP: Perimeter elasticity constant.
         Lambda: Tension difference between non-contacting edges and contacting edges.
         delta: Contact truncation threshold to avoid singularities in computations; if None, set to 0.45*r.
+        seed: Random seed for reproducibility; used by :py:meth:`get_steady_state` and :py:meth:`with_optimal_radius` for random optimization restarts, and by :py:class:`FiniteVoronoiSimulator` for fallback random sampling.
     """
     
     r: float = 1.0               #: Radius (maximal) of the Voronoi cells, sometimes denoted as :math:`\ell`.
@@ -57,6 +77,7 @@ class PhysicalParams:
     KP: float = 1.0              #: Perimeter elasticity constant.
     Lambda: float = 0.2  #: Tension difference between non-contacting edges and contacting edges.
     delta: float | None = None   #: Contact truncation threshold to avoid singularities in computations.
+    seed: int | None = None      #: Random seed for reproducibility; used by :py:meth:`get_steady_state` and :py:meth:`with_optimal_radius` for random optimization restarts, and by :py:class:`FiniteVoronoiSimulator` for fallback random sampling.
 
     def __post_init__(self):
         # Normalize and validate required scalar floats
@@ -66,6 +87,7 @@ class PhysicalParams:
         object.__setattr__(self, "KA", _require_float_scalar(self.KA, "KA"))
         object.__setattr__(self, "KP", _require_float_scalar(self.KP, "KP"))
         object.__setattr__(self, "Lambda", _require_float_scalar(self.Lambda, "Lambda"))
+        object.__setattr__(self, "seed", _require_nonnegative_int_scalar(self.seed, "seed") if self.seed is not None else None)
 
         if self.delta is None:
             object.__setattr__(self, "delta", 0.45 * self.r)
@@ -147,18 +169,18 @@ class PhysicalParams:
         KA, KP, A0, P0, Lambda = params
         return KA * (A - A0)**2 + KP * (P - P0)**2 + Lambda * ln
 
-    def _minimize_energy(self, params, restarts=10, seed=None):
+    def _minimize_energy(self, params, restarts=10):
 
         from scipy.optimize import minimize
         
-        rng = np.random.default_rng(seed)
+        rng = np.random.default_rng(self.seed)
         best = None
         for _ in range(restarts):
             z0 = rng.normal(size=2)
 
             with np.errstate(over='ignore', invalid='ignore'):    # suppress overflow warnings in exp() during optimization
                 res = minimize(lambda z: self._energy_unconstrained(z, params), z0, method="BFGS",
-                            options={"gtol": 1e-8, "maxiter": 1e4})
+                            options={"gtol": 1e-8, "maxiter": 10_000})
             val = res.fun
             z = res.x
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,12 @@ exclude = ["assets/", "docs/", "examples/jupyter/", "*.md", ".*"]
 testpaths = ["tests"]
 addopts = "--benchmark-skip"  # skip benchmarks by default
 # pythonpath = ["."]  # not needed if package is installed
-# filter warnings from matplotlib about pyparsing
 filterwarnings = [
+    # filter warnings from matplotlib about pyparsing
     "ignore:'oneOf' deprecated:DeprecationWarning",
     "ignore:'parseString' deprecated:DeprecationWarning",
     "ignore:'resetCache' deprecated:DeprecationWarning",
-    "ignore:'enablePackrat' deprecated:DeprecationWarning"
+    "ignore:'enablePackrat' deprecated:DeprecationWarning",
+    # filter some custom warnings
+    "ignore:.*At least one inner vertex is associated with 4 or more points.*:RuntimeWarning",
 ]


### PR DESCRIPTION
Revisions in response to the referee report. Groups a few related improvements to `PhysicalParams`, calibration, and the finite-Voronoi core, plus documentation updates.

- **Expose `seed` in `PhysicalParams`** — a validated non-negative-int field for reproducibility, threaded through `get_steady_state`, `with_optimal_radius` (random optimization restarts), and `FiniteVoronoiSimulator` fallback sampling. Drops the ad-hoc `seed=` argument from `_minimize_energy`.
- **Expose `num_vertices` to `auto_calibrate`** — lets callers override the `DeformablePolygonSimulator` default vertex count $M$.
- **Rosette fallback warning** — when an inner vertex is associated with 4+ points, resample the triple from the original rosette structure (rather than any point, #38 and #42) and emit a `RuntimeWarning`.
- **Contact-truncation docs** — `build()` now documents that a non-zero $\delta$ means the force near detachment is not $-\nabla E$ from a smooth energy, with the caveats for energy-/Hessian-based analyses.
- **Example + docs** — `active_FV.py` now uses the default (truncated) $\delta$; docs show both the default and $\delta=0$ figures side by side.